### PR TITLE
Auto_Crafters.md

### DIFF
--- a/Machines/Auto Crafters
+++ b/Machines/Auto Crafters
@@ -1,0 +1,7 @@
+Auto crafters are an automated way to get your crafting needs met (duh). There are 3 different tiers from 1-3, each tier they craft much faster but also use more energy. Tier 1 costs 5k, Tier 2 10k, and Tier 3 20k. /advance them all to auto craft what ever you want!
+To build the auto crafter you will need 8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 3 Glass blocks, 2 Titanium blocks, 3 droppers, 1 noteblock, 1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods
+<a href="https://gyazo.com/31e73021635a2ce3baf62e67972c701d"><img src="https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png" alt="Image from Gyazo" width="690"/></a>
+<a href="https://gyazo.com/18da692ced557272ece3967c569df8f7"><img src="https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png" alt="Image from Gyazo" width="410"/></a>
+<a href="https://gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3"><img src="https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png" alt="Image from Gyazo" width="452"/></a>
+<a href="https://gyazo.com/429eb5e6b5902d814b9f1adf714f54ae"><img src="https://i.gyazo.com/429eb5e6b5902d814b9f1adf714f54ae.png" alt="Image from Gyazo" width="627"/></a>
+<a href="https://gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24"><img src="https://i.gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24.png" alt="Image from Gyazo" width="281"/></a>

--- a/Machines/Auto Crafters
+++ b/Machines/Auto Crafters
@@ -1,7 +1,0 @@
-Auto crafters are an automated way to get your crafting needs met (duh). There are 3 different tiers from 1-3, each tier they craft much faster but also use more energy. Tier 1 costs 5k, Tier 2 10k, and Tier 3 20k. /advance them all to auto craft what ever you want!
-To build the auto crafter you will need 8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 3 Glass blocks, 2 Titanium blocks, 3 droppers, 1 noteblock, 1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods
-<a href="https://gyazo.com/31e73021635a2ce3baf62e67972c701d"><img src="https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png" alt="Image from Gyazo" width="690"/></a>
-<a href="https://gyazo.com/18da692ced557272ece3967c569df8f7"><img src="https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png" alt="Image from Gyazo" width="410"/></a>
-<a href="https://gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3"><img src="https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png" alt="Image from Gyazo" width="452"/></a>
-<a href="https://gyazo.com/429eb5e6b5902d814b9f1adf714f54ae"><img src="https://i.gyazo.com/429eb5e6b5902d814b9f1adf714f54ae.png" alt="Image from Gyazo" width="627"/></a>
-<a href="https://gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24"><img src="https://i.gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24.png" alt="Image from Gyazo" width="281"/></a>

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -17,7 +17,8 @@ Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more 
 
 ## Multiblock
 ### Requirements
-8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 
+* 8 Tier blocks (Iron, Gold, or Diamond) 
+* 8 Glass Panes
 * 3x glass block
 * 2x titanium block
 * 3x dropper

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -12,7 +12,7 @@ To unlock them, use i.e. `/advance AUTO_CRAFTER_ONE`. They cost C5,000, C10,000,
 
 - Put `[autocrafter]` on the first line of the sign
 - The input container is the container on the left side of the multiblock, atop the glass block.
-- Output is the dropper on the other side on top of the crafting table.
+- The output container is the container on the right side of the multiblock, atop the crafting table.
 - Using items form the recipe in the middle dropper as if it were a crafting table.
 
 ## Multiblock

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -19,8 +19,8 @@ To build the auto crafter you will need:
 8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 
 3 Glass blocks, 2 Titanium blocks, 3 droppers, 1 noteblock, 
 1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods
-[![Image from Gyazo](https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png)](https://gyazo.com/31e73021635a2ce3baf62e67972c701d)
-[![Image from Gyazo](https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png)](https://gyazo.com/18da692ced557272ece3967c569df8f7)
-[![Image from Gyazo](https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png)](https://gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3)
-[![Image from Gyazo](https://i.gyazo.com/429eb5e6b5902d814b9f1adf714f54ae.png)](https://gyazo.com/429eb5e6b5902d814b9f1adf714f54ae)
-[![Image from Gyazo](https://i.gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24.png)](https://gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24)
+![Image from Gyazo](https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png)
+![Image from Gyazo](https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png)
+![Image from Gyazo](https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png)
+![Image from Gyazo](https://i.gyazo.com/429eb5e6b5902d814b9f1adf714f54ae.png)
+![Image from Gyazo](https://i.gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24.png)

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -10,7 +10,7 @@ To unlock them, use i.e. `/advance AUTO_CRAFTER_ONE`. They cost C5,000, C10,000,
 
 ## Usage
 
-- Make sure the sign on the auto crafter says [AutoCrafter]
+- Put `[autocrafter]` on the first line of the sign
 - The Input is the dropper on top of the glass, left of the sign.
 - Output is the dropper on the other side on top of the crafting table.
 - Using items form the recipe in the middle dropper as if it were a crafting table.

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -1,5 +1,6 @@
 # Auto Crafters
-Auto crafters are an automated way to get your crafting needs met (duh). 
+Auto crafters are machines used to mass produce a specific crafting recipe using input and output chests,
+crafting the recipe given in the recipe holder dropper/dispenser block.
 Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more power).
 - **Tier 1** (Iron) (2 crafts/second) (200,000 power capacity)
 - **Tier 2** (Gold) (4 crafts/second) (400,000 power capacity)

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -8,7 +8,7 @@ Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more 
 
 To unlock them, use i.e. `/advance AUTO_CRAFTER_ONE`. They cost C5,000, C10,000, and C20,000.
 
-## To Use Auto Crafters
+## Usage
 
 - Make sure the sign on the auto crafter says [AutoCrafter]
 - The Input is the dropper on top of the glass, left of the sign.

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -14,7 +14,7 @@ Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more 
 - Output is the dropper on the other side on top of the crafting table.
 - Using items form the recipe in the middle dropper as if it were a crafting table.
 
-## To Make an Auto Crafter
+## Multiblock
 ### Requirements
 8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 
 * 3x glass block

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -1,7 +1,7 @@
 # Auto Crafters
 Auto crafters are an automated way to get your crafting needs met (duh). 
 Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more power).
-- Tier 1 costs 5k
+- **Tier 1** (Iron) (2 crafts/second) (200,000 power capacity)
 - Tier 2 10k,
 - Tier 3 20k. 
 

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -6,7 +6,7 @@ Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more 
 - **Tier 2** (Gold) (4 crafts/second) (400,000 power capacity)
 - **Tier 3** (Diamond) (6 crafts/second) (600,000 power capacity)
 
-/advance them all to auto craft what ever you want!
+To unlock them, use i.e. `/advance AUTO_CRAFTER_ONE`. They cost C5,000, C10,000, and C20,000.
 
 ## To Use Auto Crafters
 

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -3,7 +3,7 @@ Auto crafters are an automated way to get your crafting needs met (duh).
 Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more power).
 - **Tier 1** (Iron) (2 crafts/second) (200,000 power capacity)
 - Tier 2 10k,
-- Tier 3 20k. 
+- **Tier 3** (Diamond) (6 crafts/second) (600,000 power capacity)
 
 /advance them all to auto craft what ever you want!
 

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -1,0 +1,26 @@
+# Auto Crafters
+Auto crafters are an automated way to get your crafting needs met (duh). 
+There are 3 different tiers from 1-3, each tier they craft much faster but also use more energy. 
+- Tier 1 costs 5k
+- Tier 2 10k,
+- Tier 3 20k. 
+
+/advance them all to auto craft what ever you want!
+
+## To Use Auto Crafters
+
+- Make sure the sign on the auto crafter says [AutoCrafter]
+- The Input is the dropper on top of the glass, left of the sign.
+- Output is the dropper on the other side on top of the crafting table.
+- Using items form the recipe in the middle dropper as if it were a crafting table.
+
+## To Make an Auto Crafter
+To build the auto crafter you will need:
+8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 
+3 Glass blocks, 2 Titanium blocks, 3 droppers, 1 noteblock, 
+1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods
+[![Image from Gyazo](https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png)](https://gyazo.com/31e73021635a2ce3baf62e67972c701d)
+[![Image from Gyazo](https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png)](https://gyazo.com/18da692ced557272ece3967c569df8f7)
+[![Image from Gyazo](https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png)](https://gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3)
+[![Image from Gyazo](https://i.gyazo.com/429eb5e6b5902d814b9f1adf714f54ae.png)](https://gyazo.com/429eb5e6b5902d814b9f1adf714f54ae)
+[![Image from Gyazo](https://i.gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24.png)](https://gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24)

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -21,7 +21,8 @@ Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more 
 * 2x titanium block
 * 3x dropper
 * 1x wire input computer (note block) 
-1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods
+* 1x furnace
+* 2x wire (end rod)
 ![Image from Gyazo](https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png)
 ![Image from Gyazo](https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png)
 ![Image from Gyazo](https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png)

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -17,7 +17,10 @@ Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more 
 ## To Make an Auto Crafter
 ### Requirements
 8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 
-3 Glass blocks, 2 Titanium blocks, 3 droppers, 1 noteblock, 
+* 3x glass block
+* 2x titanium block
+* 3x dropper
+* 1x wire input computer (note block) 
 1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods
 ![Image from Gyazo](https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png)
 ![Image from Gyazo](https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png)

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -1,6 +1,6 @@
 # Auto Crafters
 Auto crafters are an automated way to get your crafting needs met (duh). 
-There are 3 different tiers from 1-3, each tier they craft much faster but also use more energy. 
+Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more power).
 - Tier 1 costs 5k
 - Tier 2 10k,
 - Tier 3 20k. 

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -13,7 +13,7 @@ To unlock them, use i.e. `/advance AUTO_CRAFTER_ONE`. They cost C5,000, C10,000,
 - Put `[autocrafter]` on the first line of the sign
 - The input container is the container on the left side of the multiblock, atop the glass block.
 - The output container is the container on the right side of the multiblock, atop the crafting table.
-- Using items form the recipe in the middle dropper as if it were a crafting table.
+- In the dropper/dispenser in the center, place the recipe as if you were crafting the item normally.
 
 ## Multiblock
 ### Requirements

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -15,7 +15,7 @@ Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more 
 - Using items form the recipe in the middle dropper as if it were a crafting table.
 
 ## To Make an Auto Crafter
-To build the auto crafter you will need:
+### Requirements
 8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 
 3 Glass blocks, 2 Titanium blocks, 3 droppers, 1 noteblock, 
 1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -11,7 +11,7 @@ To unlock them, use i.e. `/advance AUTO_CRAFTER_ONE`. They cost C5,000, C10,000,
 ## Usage
 
 - Put `[autocrafter]` on the first line of the sign
-- The Input is the dropper on top of the glass, left of the sign.
+- The input container is the container on the left side of the multiblock, atop the glass block.
 - Output is the dropper on the other side on top of the crafting table.
 - Using items form the recipe in the middle dropper as if it were a crafting table.
 

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -25,6 +25,8 @@ To unlock them, use i.e. `/advance AUTO_CRAFTER_ONE`. They cost C5,000, C10,000,
 * 1x wire input computer (note block) 
 * 1x furnace
 * 2x wire (end rod)
+
+### Images
 ![Image from Gyazo](https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png)
 ![Image from Gyazo](https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png)
 ![Image from Gyazo](https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png)

--- a/Machines/Auto_Crafters.md
+++ b/Machines/Auto_Crafters.md
@@ -2,7 +2,7 @@
 Auto crafters are an automated way to get your crafting needs met (duh). 
 Auto Crafters come in 3 tiers. Higher tiers craft items faster (thus using more power).
 - **Tier 1** (Iron) (2 crafts/second) (200,000 power capacity)
-- Tier 2 10k,
+- **Tier 2** (Gold) (4 crafts/second) (400,000 power capacity)
 - **Tier 3** (Diamond) (6 crafts/second) (600,000 power capacity)
 
 /advance them all to auto craft what ever you want!


### PR DESCRIPTION
# Auto Crafters
Auto crafters are an automated way to get your crafting needs met (duh). 
There are 3 different tiers from 1-3, each tier they craft much faster but also use more energy. 
- Tier 1 costs 5k
- Tier 2 10k,
- Tier 3 20k. 

/advance them all to auto craft what ever you want!

## To Use Auto Crafters

- Make sure the sign on the auto crafter says [AutoCrafter]
- The Input is the dropper on top of the glass, left of the sign.
- Output is the dropper on the other side on top of the crafting table.
- Using items form the recipe in the middle dropper as if it were a crafting table.

## To Make an Auto Crafter
To build the auto crafter you will need:
8 Tier blocks, (Iron, Gold, or Diamond) 8 Glass Panes, 
3 Glass blocks, 2 Titanium blocks, 3 droppers, 1 noteblock, 
1 furnace (with 1 focusing lens in each slot), and 2 wire/end rods
[![Image from Gyazo](https://i.gyazo.com/31e73021635a2ce3baf62e67972c701d.png)](https://gyazo.com/31e73021635a2ce3baf62e67972c701d)
[![Image from Gyazo](https://i.gyazo.com/18da692ced557272ece3967c569df8f7.png)](https://gyazo.com/18da692ced557272ece3967c569df8f7)
[![Image from Gyazo](https://i.gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3.png)](https://gyazo.com/d42acba4ee5b58ec9092fb947a3db8d3)
[![Image from Gyazo](https://i.gyazo.com/429eb5e6b5902d814b9f1adf714f54ae.png)](https://gyazo.com/429eb5e6b5902d814b9f1adf714f54ae)
[![Image from Gyazo](https://i.gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24.png)](https://gyazo.com/44ee0a0a497b19c1a10ab6c7b58dda24)